### PR TITLE
Outline the CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ license     = "MIT"
 keywords    = ["json", "json-refs", "utilities"]
 
 [dependencies]
+clap = "~2.27.0"

--- a/src/bin/json-ref.rs
+++ b/src/bin/json-ref.rs
@@ -1,10 +1,13 @@
 extern crate clap;
 extern crate json_ref;
 
-use clap::{App, AppSettings, SubCommand};
+use std::collections::HashMap;
+
+use clap::{App, AppSettings, ArgMatches, SubCommand};
+use json_ref::Command;
 
 fn main() {
-    App::new("json-ref")
+    let matches = App::new("json-ref")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
@@ -25,4 +28,23 @@ fn main() {
                 .arg_from_usage("<URI> 'The URI to validate. Can be a file or URL.'"),
         )
         .get_matches();
+
+    if let (cmd, Some(matches)) = matches.subcommand() {
+        if let Ok(c) = cmd.parse::<Command>() {
+            c.execute(args_for_command(c, &matches));
+        }
+    }
+}
+
+fn args_for_command<'a>(cmd: Command, matches: &'a ArgMatches) -> HashMap<&'a str, &'a str> {
+    let mut args = HashMap::new();
+    args.insert("URI", matches.value_of("URI").unwrap());
+
+    if cmd == Command::Resolve {
+        if matches.is_present("yaml") {
+            args.insert("yaml", "true");
+        }
+    }
+
+    args
 }

--- a/src/bin/json-ref.rs
+++ b/src/bin/json-ref.rs
@@ -1,0 +1,28 @@
+extern crate clap;
+extern crate json_ref;
+
+use clap::{App, AppSettings, SubCommand};
+
+fn main() {
+    App::new("json-ref")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .setting(AppSettings::GlobalVersion)
+        .setting(AppSettings::UnifiedHelpMessage)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            SubCommand::with_name("resolve")
+                .about("Prints the document with all references resolved")
+                .args_from_usage(
+                    "<URI> 'The URI to parse. Can be a file or URL.'
+                    -y, --yaml 'Output result in YAML",
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("validate")
+                .about("Validates that all references in the document are resolveable")
+                .arg_from_usage("<URI> 'The URI to validate. Can be a file or URL.'"),
+        )
+        .get_matches();
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+/// An enum representing the available commands
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Command {
+    /// Prints the document with all references resolved
+    Resolve,
+    /// Validates that all references in the document are resolveable
+    Validate,
+}
+
+impl fmt::Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl FromStr for Command {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "resolve" => Ok(Command::Resolve),
+            "validate" => Ok(Command::Validate),
+            _ => Err("not a valid command"),
+        }
+    }
+}
+
+impl Command {
+    /// Executes the command with the given arguments
+    pub fn execute(self, args: HashMap<&str, &str>) {
+        if let Some(uri) = args.get("URI") {
+            match self {
+                Command::Resolve => resolve(uri, args.contains_key("yaml")),
+                Command::Validate => validate(uri),
+            }
+        }
+    }
+}
+
+fn resolve(uri: &str, is_yaml: bool) {
+    // TODO: Do something valuable
+    println!("Running resolve with uri: {}, yaml: {}", uri, is_yaml);
+}
+
+fn validate(uri: &str) {
+    // TODO: Do something valuable
+    println!("Running validate with uri: {}", uri);
+}
+
+#[cfg(test)]
+mod test {
+    use super::Command;
+
+    #[test]
+    fn debug_and_display_output() {
+        assert_eq!("Found Resolve", format!("Found {:?}", Command::Resolve));
+        assert_eq!("Found Validate", format!("Found {:?}", Command::Validate));
+
+        assert_eq!("Found Resolve", format!("Found {}", Command::Resolve));
+        assert_eq!("Found Validate", format!("Found {}", Command::Validate));
+    }
+
+    #[test]
+    fn from_string() {
+        assert_eq!(Ok(Command::Resolve), "resolve".parse());
+        assert_eq!(Ok(Command::Resolve), "RESOLVE".parse());
+
+        assert_eq!(Ok(Command::Validate), "validate".parse());
+        assert_eq!(Ok(Command::Validate), "VALIDATE".parse());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 //! json-ref provides a CLI for joining multiple JSON/YAML documents by resolving `$ref` fields
 //! according to the [JSON Ref](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) specs.
 
+mod commands;
+
+pub use commands::Command;
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Adding just enough code to make the CLI look right. The actual commands (resolve and validate) don't do anything at the moment other the print their context.

```bash
cargo run -- help
```

**Output**
```
json-ref 0.1.0
David Muto (pseudomuto) <david.muto@gmail.com>
A simple tool for resolving/validation json-refs across documents.

USAGE:
    json-ref <SUBCOMMAND>

OPTIONS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help        Prints this message or the help of the given subcommand(s)
    resolve     Prints the document with all references resolved
    validate    Validates that all references in the document are resolveable
```